### PR TITLE
Prevent running inside a minibuffer-only frame

### DIFF
--- a/vertico-posframe.el
+++ b/vertico-posframe.el
@@ -232,7 +232,8 @@ vertico-posframe works with vertico multiform toggle."
 (defun vertico-posframe-mode-workable-p ()
   "Test `vertico-posframe-mode' is actived and can work or not."
   (and vertico-posframe-mode
-       (posframe-workable-p)))
+       (posframe-workable-p)
+       (not (vertico-posframe--minibuffer-only-p))))
 
 (defun vertico-posframe--minibuffer-exit-hook ()
   "The function used by `minibuffer-exit-hook'."
@@ -240,6 +241,12 @@ vertico-posframe works with vertico multiform toggle."
   ;; 1.0, so I think setting it to 1.0 here is safe :-).
   (setq-local max-mini-window-height 1.0)
   (posframe-hide vertico-posframe--buffer))
+
+(defun vertico-posframe--minibuffer-only-p ()
+  "Check if the selected frame is a minibuffer-only frame."
+  (let ((current-frame (selected-frame)))
+    (and (framep current-frame)
+         (eq (frame-parameter current-frame 'minibuffer) 'only))))
 
 (cl-defmethod vertico--resize-window
   (_height &context ((vertico-posframe-mode-workable-p) (eql t))))

--- a/vertico-posframe.el
+++ b/vertico-posframe.el
@@ -264,9 +264,11 @@ vertico-posframe works with vertico multiform toggle."
         (minibuffer-window (active-minibuffer-window)))
     (setq-local max-mini-window-height 1)
     ;; Let minibuffer-window's height = 1
-    (window-resize minibuffer-window
-                   (- (window-pixel-height minibuffer-window))
-                   nil nil 'pixelwise)
+    (condition-case err
+	(window-resize minibuffer-window
+                       (- (window-pixel-height minibuffer-window))
+                       nil nil 'pixelwise)
+      (error (warn "vertico-posframe.el: %s Aborting..." (cdr err))))
     ;; Hide the context showed in minibuffer-window.
     (set-window-vscroll minibuffer-window 100)
     (when show-minibuffer-p


### PR DESCRIPTION
This PR prevents `posframe` from running if the currently selected frame is a **minibuffer-only** frame and also **aborts** when `window-resize` errors occur.

I've recently been trying to use **Emacs** (or more accurately **Vertico**) as a launcher like dmenu. However, I also use `vertico-posframe` to display Vertico candidates in normal Emacs frames.

I can achieve this using `make-frame` with the option `(minibuffer . only)`. However, we certainly don't want a *posframe* inside a *minibuffer*.
