### PR TITLE
Update vertico-posframe.el

### DIFF
--- a/vertico-posframe.el
+++ b/vertico-posframe.el
@@ -5,7 +5,7 @@
 ;; Author: Feng Shu <tumashu@163.com>
 ;; Maintainer: Feng Shu <tumashu@163.com>
 ;; URL: https://github.com/tumashu/vertico-posframe
-;; Version: 0.7.7
+;; Version: 0.7.8
 ;; Keywords: abbrev, convenience, matching, vertico
 ;; Package-Requires: ((emacs "26.0") (posframe "1.4.0") (vertico "1.1"))
 


### PR DESCRIPTION
Update after breaking change in #52. 

Need version update for GNU Elpa to publish the updated package.