### PR TITLE
Update vertico-posframe-vertico-multiform-key default

### DIFF
--- a/vertico-posframe.el
+++ b/vertico-posframe.el
@@ -145,7 +145,7 @@ a rule can be a regexp or a function.
 minibuffer will not be hided by minibuffer-cover."
   :type '(repeat (choice string function)))
 
-(defcustom vertico-posframe-vertico-multiform-key "M-p"
+(defcustom vertico-posframe-vertico-multiform-key "M-P"
   "The vertico-posframe keybinding used in vertico-multiform."
   :type '(choice (const nil) string))
 


### PR DESCRIPTION
The current default of M-p conflicts with the `previous-history-element` keybinding in the minibuffer. This commit updates the default to M-P, which is consistent with the other default vertico-multiform keybindings.