### PR TITLE
Use cursor-type as the cursor value

### DIFF
--- a/vertico-posframe.el
+++ b/vertico-posframe.el
@@ -307,7 +307,7 @@ vertico-posframe works with vertico multiform toggle."
         (setq-local vertico-posframe--use-auto-hscroll-mode-p t)))
     (apply #'posframe-show
            buffer
-           :cursor 'box
+           :cursor cursor-type
            :tty-non-selected-cursor t
            :window-point window-point
            :font (buffer-local-value 'vertico-posframe-font buffer)


### PR DESCRIPTION
Make the cursor fit the one already being used.

Closes https://github.com/tumashu/vertico-posframe/issues/38 (kind of).

![05:33 PM 17-01-2025](https://github.com/user-attachments/assets/9d7d0d73-4365-40d5-832d-83a2f7126a32)
