### PR TITLE
Fix vertico-multiform support

### DIFF
--- a/vertico-posframe.el
+++ b/vertico-posframe.el
@@ -212,9 +212,7 @@ vertico-posframe works with vertico multiform toggle."
          (mode (intern (format "vertico-%s-mode" name)))
          (toggle (intern (format "vertico-multiform-%s" name))))
     (defalias toggle
-      (lambda ()
-        (interactive)
-        (vertico-multiform-vertical mode))
+      (lambda () (interactive) (vertico-multiform--toggle-mode mode))
       (format "Toggle the %s display." name))
     (push mode vertico-multiform--display-modes)
     (put toggle 'completion-predicate #'vertico--command-p)


### PR DESCRIPTION
This commit solves a `(wrong-number-of-arguments (0 . 0) 1)` issue caused by a change in the vertico-multiform internals some months ago (see [the breaking upstream commit](https://github.com/minad/vertico/commit/8b74fd1f5fde99e35d98e6ada5fb138518018051#diff-b234dd8ac0804ec1ff8abd7f43a1f77ec30c82e75384b4e57efe36ce92988453L224)).